### PR TITLE
Bump PyExpUtils from 1.6 to 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/andnp/RlGlue@0.2#egg=RlGlue
-git+https://github.com/andnp/PyExpUtils@1.6#egg=PyExpUtils
+git+https://github.com/andnp/PyExpUtils@1.8#egg=PyExpUtils
 git+https://github.com/andnp/PyFixedReps@0.1#egg=PyFixedReps
 
 matplotlib>=2.2.3


### PR DESCRIPTION
## Description

Just a version bump on PyExpUtils to fix a bug.

## Before

Invoking a local sweep would throw file not found because [a list of paths was stored as a string in `ArgsModel`](https://github.com/andnp/PyExpUtils/blob/1.6/PyExpUtils/runner/Args.py#L6).

```
$ python scripts/local.py src/main.py 10 results experiments/example/SARSA.json

Traceback (most recent call last):
  File "scripts/local.py", line 40, in <module>
    exp = Experiment.load(path)
  File "/Users/kdbanman/dev/RL-control-template/src/experiment/ExperimentModel.py", line 16, in load
    with open(path, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '['
```

## After

The same invocation succeeds.

```
$ python scripts/local.py src/main.py 10 results experiments/example/SARSA.json
15
14/15
```

## QA

Local runs work as per before/after above.  For slurm codepaths, I tested with the following `cedar.json` config:

```json
{
    "account": "def-whitem",
    "time": "0:59:00",
    "nodes": 1,
    "memPerCpu": "2G",
    "tasksPerNode": 8
}
```

and with the following call:

```
$ python scripts/slurm.py clusters/cedar.json src/main.py ./ 100 experiments/example/SARSA.json

experiments/example/SARSA.json
scheduling: experiments/example/SARSA.json [0, 1, 2, 3, 4, 5, 6, 7]
Submitted batch job 43027493
scheduling: experiments/example/SARSA.json [8, 9, 10, 11, 12, 13, 14]
Submitted batch job 43027503
```

The above output shows that scheduler took the jobs, and `sq` agrees:

```
$ sq

          JOBID     USER      ACCOUNT           NAME  ST  TIME_LEFT NODES CPUS TRES_PER_N MIN_MEM NODELIST (REASON)
       43027493 kdbanman def-whitem_c  auto_slurm.sh  PD      59:00     1    1        N/A      2G  (Priority)
       43027503 kdbanman def-whitem_c  auto_slurm.sh  PD      59:00     1    1        N/A      2G  (Priority)
```

After the jobs were run, the `results/` directory is populated:

```
$ tree -L 4 results/
results/
└── example
    └── SARSA
        ├── alpha-0.5_epsilon-0.05
        │   └── return_summary.npy
        ├── alpha-0.6_epsilon-0.05
        │   └── return_summary.npy
        ├── alpha-0.6_epsilon-0.1
        │   └── return_summary.npy
        ├── alpha-0.7_epsilon-0.1
        │   └── return_summary.npy
        ├── alpha-0.8_epsilon-0.1
        │   └── return_summary.npy
        ├── alpha-0.8_epsilon-0.15
        │   └── return_summary.npy
        ├── alpha-0.9_epsilon-0.1
        │   └── return_summary.npy
        └── alpha-0.9_epsilon-0.15
            └── return_summary.npy

10 directories, 8 files
```